### PR TITLE
Downloading GGML model from Huggingface hub

### DIFF
--- a/lm-hackers.ipynb
+++ b/lm-hackers.ipynb
@@ -2513,7 +2513,15 @@
     }
    ],
    "source": [
-    "llm = Llama(model_path=\"/home/jhoward/git/llamacpp/llama-2-7b-chat.Q4_K_M.gguf\")"
+    "# Download model from HF hub\n",
+    "from huggingface_hub import hf_hub_download; \n",
+    "downloaded_model_path = hf_hub_download(repo_id='TheBloke/Llama-2-7b-Chat-GGUF',\n",
+    "    filename='llama-2-7b-chat.Q4_K_M.gguf',\n",
+    "    use_auth_token=True\n",
+    "    )\n",
+    "\n",
+    "# Create model\n",
+    "llm = Llama(model_path=downloaded_model_path)"
    ]
   },
   {


### PR DESCRIPTION
Downloading `llama-2-7b-chat.Q4_K_M.gguf` from Huggingface when needed instead of relying on the pre-downloaded copy.