### PR TITLE
Run notebook end-to-end with GTX 3090/4090

### DIFF
--- a/lm-hackers.ipynb
+++ b/lm-hackers.ipynb
@@ -1258,6 +1258,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "6e769bff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Funciton to clean memory before using new model\n",
+    "import gc\n",
+    "\n",
+    "# Conveninence function\n",
+    "def get_cuda_memory_reserved_gb():\n",
+    "    return torch.cuda.memory_reserved()/1_000_000_000\n",
+    "    \n",
+    "def free_memory(verbose=False):\n",
+    "    gc.collect() \n",
+    "    torch.cuda.empty_cache()\n",
+    "    if verbose:\n",
+    "        print(f'ℹ️ CUDA MEMORY RESERVED AFTER free_memory: {get_cuda_memory_reserved_gb()} GB')    \n",
+    "\n",
+    "# Let's see how it works:\n",
+    "print(f'BREFORE free_memory: {get_cuda_memory_reserved_gb()} GB')\n",
+    "del model # Delete model to be able to free memory\n",
+    "print(f'BREFORE free_memory after deleting `model`: {get_cuda_memory_reserved_gb()} GB')\n",
+    "free_memory(verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 28,
    "id": "15311da3-bfc0-4453-b4a8-6a9773db626b",
    "metadata": {},
@@ -1321,7 +1348,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = AutoModelForCausalLM.from_pretrained('TheBloke/Llama-2-7b-Chat-GPTQ', device_map=0, torch_dtype=torch.float16)"
+    "del model; free_memory(True); # Cleanup before loading new one\n",
+    "model = AutoModelForCausalLM.from_pretrained('TheBloke/Llama-2-7b-Chat-GPTQ', device_map=0, torch_dtype=torch.float16)\n",
+    "print(f'CUDA MEMORY RESERVED AFTER LOADING model: {get_cuda_memory_reserved_gb()} GB')"
    ]
   },
   {
@@ -1364,6 +1393,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "del model; free_memory();\n",
     "mn = 'TheBloke/Llama-2-13B-GPTQ'\n",
     "model = AutoModelForCausalLM.from_pretrained(mn, device_map=0, torch_dtype=torch.float16)"
    ]
@@ -1465,6 +1495,7 @@
     }
    ],
    "source": [
+    "del model; free_memory();\n",
     "mn = \"stabilityai/StableBeluga-7B\"\n",
     "model = AutoModelForCausalLM.from_pretrained(mn, device_map=0, torch_dtype=torch.bfloat16)"
    ]
@@ -1535,6 +1566,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "del model; free_memory();\n",
     "mn = 'TheBloke/OpenOrca-Platypus2-13B-GPTQ'\n",
     "model = AutoModelForCausalLM.from_pretrained(mn, device_map=0, torch_dtype=torch.float16)"
    ]
@@ -2069,6 +2101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "del model; free_memory();\n",
     "model = AutoModelForCausalLM.from_pretrained('meta-llama/Llama-2-7b-hf',\n",
     "                                             torch_dtype=torch.bfloat16, device_map=0)\n",
     "model = PeftModel.from_pretrained(model, ax_model)\n",
@@ -2117,6 +2150,17 @@
    ],
    "source": [
     "print(tokr.batch_decode(res)[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b17c43c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Finally release model and memory\n",
+    "del model; free_memory(True);"
    ]
   },
   {


### PR DESCRIPTION
The main purpose of this PR is to enable users with RTX 3090/4090 cards to run the `lm-hackers.ipynb` notebook end-to-end. To achieve this, we need to free both the host and GPU memory before loading a new model. The free_memory function below was borrowed from miniai:

```python
def free_memory(verbose=False):
    gc.collect() 
    torch.cuda.empty_cache()
    if verbose: print(f'ℹ️ CUDA MEMORY RESERVED AFTER free_memory: {get_cuda_memory_reserved_gb()} GB')    
```

Before loading a new model, the current model is deleted, and the `free_memory` function is called:

```python
del model; free_memory();
mn = "stabilityai/StableBeluga-7B"
model = AutoModelForCausalLM.from_pretrained(mn, device_map=0, torch_dtype=torch.bfloat16)
``` 

NOTE: It's essential to use `del model` before `free_memory` to ensure that the memory is released before reassignment. Failing to do so might result in a working memory exceeding 24GB.