### PR TITLE
Set axolotl qlora-out as subfolder of notebook directory. 

### DIFF
--- a/lm-hackers.ipynb
+++ b/lm-hackers.ipynb
@@ -1954,6 +1954,8 @@
    "id": "e23cb868-10e4-4fcc-b8ba-9178ef3dac7e",
    "metadata": {},
    "source": [
+    "Assuming we execute this from the directory containing `lm-hackers.ipynb`, we are doing so to control the location of the `qlora-out` folder.\n",
+    "\n",
     "`accelerate launch -m axolotl.cli.train sql.yml`"
    ]
   },
@@ -2049,7 +2051,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax_model = '/home/jhoward/git/ext/axolotl/qlora-out'"
+    "ax_model = './qlora-out'"
    ]
   },
   {


### PR DESCRIPTION
This PR sets the `qlora-out` path as a subfolder of the folder containing `lm-hackers` notebook.
It's important to note that this works fine only if you run the fine tuning command:
`accelerate launch -m axolotl.cli.train sql.yml`
From the same folder containing `lm-hackers` notebook.