### PR TITLE
Fix echo and logprobs incompatibility in Completion

### DIFF
--- a/lm-hackers.ipynb
+++ b/lm-hackers.ipynb
@@ -714,7 +714,7 @@
    "outputs": [],
    "source": [
     "c = Completion.create(prompt=\"Australian Jeremy Howard is \",\n",
-    "                      model=\"gpt-3.5-turbo-instruct\", echo=True, logprobs=5)"
+    "                      model=\"gpt-3.5-turbo-instruct\", echo=False, logprobs=5)"
    ]
   },
   {


### PR DESCRIPTION
This PR aims to resolve the following error ([probably due to API change](https://community.openai.com/t/why-will-gpt-3-5-turbo-instruct-no-longer-support-echo-true-and-logprobs-1/404932)):

`InvalidRequestError: Setting 'echo' and 'logprobs' at the same time is not supported for this model.`

The original code snippet is:
```python
c = Completion.create(prompt="Australian Jeremy Howard is ",
                      model="gpt-3.5-turbo-instruct", echo=True, logprobs=5)
```

The proposed solution is setting `echo=False`.