### PR TITLE
Fix ValueError Issues in sql.yml

### DIFF
--- a/sql.yml
+++ b/sql.yml
@@ -10,7 +10,8 @@ strict: false
 
 datasets:
   - path: knowrohit07/know_sql
-    type: context_qa2
+    type: context_qa.load_v2
+    train_on_split: validation
 dataset_prepared_path: last_run_prepared
 val_set_size: 0.01
 output_dir: ./qlora-out
@@ -59,6 +60,7 @@ flash_attention: true
 warmup_steps: 10
 eval_steps: 20
 eval_table_size: 5
+eval_sample_packing: false
 save_steps:
 debug:
 deepspeed:


### PR DESCRIPTION
This PR fixes two issues in the `sql.yml` configuration file for axolotl:

1. **Error**: `ValueError: eval_table_size and eval_sample_packing are not supported together with sample_packing. Please set 'eval_sample_packing' to false.`
   - **Solution**: Set `eval_sample_packing: false`.

2. **Error**: `ValueError: no train split found for dataset knowrohit07/know_sql, you may specify a split with 'train_on_split: ...`
   - **Solution**: Added `train_on_split: validation` as per the official [axolotl README](https://github.com/OpenAccess-AI-Collective/axolotl/blob/main/README.md).

### Changes to 

```yaml
# Issue 1.
eval_sample_packing: false

# Issue 2.
dataset:
  - path: knowrohit07/know_sql
    type: context_qa.load_v2
    train_on_split: validation
```